### PR TITLE
remove numbers from firstname and lastnane

### DIFF
--- a/app/code/community/Todopago/Modulodepago2/Model/Cybersource/Cybersource.php
+++ b/app/code/community/Todopago/Modulodepago2/Model/Cybersource/Cybersource.php
@@ -34,8 +34,8 @@ abstract class Todopago_Modulodepago2_Model_Cybersource_Cybersource extends Mage
              $payDataOperacion ['CSBTEMAIL'] = $this->getField($this->order->getCustomerEmail());
         else $payDataOperacion ['CSBTEMAIL'] = $this->getField($billingAdress->getEmail());
 
-		$payDataOperacion ['CSBTFIRSTNAME'] = $this->getField($billingAdress->getFirstname());
-		$payDataOperacion ['CSBTLASTNAME'] = $this->getField($billingAdress->getLastname());
+		$payDataOperacion ['CSBTFIRSTNAME'] = preg_replace('/[0-9]+/', '', $this->getField($billingAdress->getFirstname()));
+		$payDataOperacion ['CSBTLASTNAME'] = preg_replace('/[0-9]+/', '', $this->getField($billingAdress->getLastname()));
 		$payDataOperacion ['CSBTPOSTALCODE'] = $this->getField($billingAdress->getPostcode());
 		$payDataOperacion ['CSBTPHONENUMBER'] = $this->getField($billingAdress->getTelephone());
 		$payDataOperacion ['CSBTSTATE'] =  strtoupper(substr($this->getField($billingAdress->getRegion()),0,1));

--- a/app/code/community/Todopago/Modulodepago2/Model/Cybersource/Retail.php
+++ b/app/code/community/Todopago/Modulodepago2/Model/Cybersource/Retail.php
@@ -12,8 +12,8 @@ class Todopago_Modulodepago2_Model_Cybersource_Retail extends Todopago_Modulodep
              $payDataOperacion ['CSSTEMAIL'] = $this->getField($this->order->getCustomerEmail());
         else $payDataOperacion ['CSSTEMAIL'] = $this->getField($shippingAdress->getEmail());  
 
-        $payDataOperacion ['CSSTFIRSTNAME'] = $this->getField($shippingAdress->getFirstname());
-        $payDataOperacion ['CSSTLASTNAME'] = $this->getField($shippingAdress->getLastname());
+        $payDataOperacion ['CSSTFIRSTNAME'] = preg_replace('/[0-9]+/', '', $this->getField($shippingAdress->getFirstname()));
+        $payDataOperacion ['CSSTLASTNAME'] = preg_replace('/[0-9]+/', '', $this->getField($shippingAdress->getLastname()));
         $payDataOperacion ['CSSTPHONENUMBER'] = $this->getField($shippingAdress->getTelephone());
         $payDataOperacion ['CSSTPOSTALCODE'] = $this->getField($shippingAdress->getPostcode());
         $payDataOperacion ['CSSTSTATE'] = strtoupper(substr($this->getField($shippingAdress->getRegion()), 0, 1));


### PR DESCRIPTION
Some payments were rejected, because billing lastname contains numbers.
json response:
{"StatusCode":98107,"StatusMessage":"ERROR: El formato del campo CSBTLASTNAME es incorrecto"}
This fix removes the issue